### PR TITLE
Fixed 4 issues of type: PYTHON_E231 throughout 2 files in repo.

### DIFF
--- a/smerkle/acc.py
+++ b/smerkle/acc.py
@@ -110,11 +110,11 @@ def compute_non_membership_witness(acc, value, g, n, values):
         assert b2 > 0
         assert a2 > 0
     except:
-        import pdb;pdb.set_trace()
+        import pdb; pdb.set_trace()
     try:
         assert a2 * value + b2 * u == 1
     except:
-        import pdb;pdb.set_trace()
+        import pdb; pdb.set_trace()
     assert a * value + b * u == 1
 
     d = mod_inverse(mod_exp(g, b2, n), n)
@@ -125,7 +125,7 @@ def compute_non_membership_witness(acc, value, g, n, values):
 def verify_non_membership_old(acc, witness_a, witness_d, value, g, n):
     left = mod_exp(acc, witness_a, n)
     right = (mod_exp(witness_d, value, n) * (g % n)) % n
-    import pdb;pdb.set_trace()
+    import pdb; pdb.set_trace()
     return left == right
 
     

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -49,7 +49,7 @@ def test_memberships():
 		assert smerkle.verify_path(path, tree.root())
 		assert smerkle.verify_nonmembership(path, tree.root(), depth)
 
-		import pdb;pdb.set_trace()
+		import pdb; pdb.set_trace()
 
 
 	


### PR DESCRIPTION
PYTHON_E231: 'missing whitespace after ‘,’, ‘;’, or ‘:’'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.