### PR TITLE
Fixed 5 issues of type: PYTHON_W291 throughout 3 files in repo.

### DIFF
--- a/smerkle/acc.py
+++ b/smerkle/acc.py
@@ -23,7 +23,7 @@ def mod_exp(a, b, n):
     k = {0: a % n}
 
     for i in range(1, len(bc)):
-        k[i] = (k[i-1] ** 2) % n       
+        k[i] = (k[i-1] ** 2) % n
 
     r = 1
     for m in range(len(bc)):

--- a/tests/test_acc.py
+++ b/tests/test_acc.py
@@ -23,10 +23,10 @@ def test_mod_exp():
     assert (a * b) % n == ((a % n) * (b % n)) % n
 
     # (a**b) mod n == ((a mod n)**b) mod n
-    # thus 
+    # thus
     # (a**(b*c)) mod n = ((a**b mod n)**c) mod n
     # thus
-    # mod_exp (a, b*c, n) = 
+    # mod_exp (a, b*c, n) =
     # mod_exp(mod_exp(a, b, n), c, n)
 
     assert smerkle.mod_exp(smerkle.mod_exp(a, b, n), c, n) == smerkle.mod_exp(a, c * b, n)
@@ -74,7 +74,7 @@ def test_add_many_memberships():
 #     n = smerkle.get_prime(digits=digits, strong=False)
 
 #     acc, witnesses = smerkle.add_many_memberships(g, values, n)
-#     #import pdb;pdb.set_trace()    
+#     #import pdb;pdb.set_trace()
 #     for v, wit in witnesses.iteritems():
 #         assert smerkle.verify_membership(acc, v, wit, n)
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -28,7 +28,7 @@ def test_memberships():
 	tree = smerkle.SMT()
 	depth = 64
 	
-	for i in range(100):	
+	for i in range(100):
 		n = random.randint(0, 2**depth-1)
 		value = str(i)
 		path = tree.add_node(n, depth, value)


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.