### PR TITLE
Fixed 12 issues of type: PYTHON_W293 throughout 4 files in repo.

### DIFF
--- a/smerkle/acc.py
+++ b/smerkle/acc.py
@@ -68,9 +68,9 @@ def add_many_memberships(acc, values, n):
 
 def compute_non_membership_witness(acc, value, g, n, values):
     # WIP, CURRENTLY BROKEN
-    
+
     # https://www.cs.purdue.edu/homes/ninghui/papers/accumulator_acns07.pdf
-    
+
     # u = multiple of all values in set
     # all values are primes
     # non-member value is X
@@ -87,7 +87,7 @@ def compute_non_membership_witness(acc, value, g, n, values):
     # to verify just show that c^a mod n == d^x * g mod n
 
     assert not value in values
-    
+
     u = 1
     for x in values:
         u = u * x
@@ -105,7 +105,7 @@ def compute_non_membership_witness(acc, value, g, n, values):
     k = max(a_diff, b_diff)
     a2 = a + k * u
     b2 = b - k * value
-    
+
     try:
         assert b2 > 0
         assert a2 > 0
@@ -128,7 +128,7 @@ def verify_non_membership_old(acc, witness_a, witness_d, value, g, n):
     import pdb;pdb.set_trace()
     return left == right
 
-    
+
 
 def xgcd(b, n):
     """

--- a/smerkle/bloom.py
+++ b/smerkle/bloom.py
@@ -44,7 +44,7 @@ class BF:
 		self.n_elements += 1
 		if self.n_elements > self.max_elements:
 			raise Exception("Cannot exceed max elements in Bloom Filter.")
-		
+
 		for i in range(self.k):
 			hv = int(self.hash_functions[i](value), 16) % self.m
 			self.array[hv] = 1
@@ -69,4 +69,4 @@ class BF:
 		b = format(i, "b")
 		b = "0" * (len(self.array) - len(b)) + b
 		self.array = [int(x) for x in b]
-		
+

--- a/smerkle/tree.py
+++ b/smerkle/tree.py
@@ -40,7 +40,7 @@ empty_hash_values = set(empty_hashes.values())
 
 
 def verify_path(path, root, hashfunction=DEFAULT_HASH_FUNCTION, max_depth=MAX_DEPTH):
-	
+
 	if not path[0] in path[1] and len(path[0]) == 1:
 		return False
 	# elif not (path[0][0] in empty_hash_values and path[0][1] in empty_hash_values):
@@ -52,7 +52,7 @@ def verify_path(path, root, hashfunction=DEFAULT_HASH_FUNCTION, max_depth=MAX_DE
 		expected_parent = hashfunction(left + right)
 		if expected_parent not in path[i+1]:
 			return False
-	
+
 	if not hashfunction(path[-1][0] + path[-1][1]) == root:
 		return False
 
@@ -112,7 +112,7 @@ class SMT:
 		self.max_depth = max_depth
 		self.hash = hashfunction
 		self.leaf_nodes = set()
-		
+
 		self.empty_hashes = dict()
 		self.empty_hashes[max_depth] = self.hash(str(max_depth) + KNOWN_RANDOMNESS)
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -27,7 +27,7 @@ def test_creation_of_tree():
 def test_memberships():
 	tree = smerkle.SMT()
 	depth = 64
-	
+
 	for i in range(100):	
 		n = random.randint(0, 2**depth-1)
 		value = str(i)
@@ -52,7 +52,7 @@ def test_memberships():
 		import pdb;pdb.set_trace()
 
 
-	
+
 
 def test_perf():
 	tree = smerkle.SMT()


### PR DESCRIPTION
PYTHON_W293: 'Remove trailing whitespace on blank line.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.