### PR TITLE
Fixed 2 issues of type: PYTHON_W391 throughout 2 files in repo.

### DIFF
--- a/smerkle/bloom.py
+++ b/smerkle/bloom.py
@@ -69,4 +69,3 @@ class BF:
 		b = format(i, "b")
 		b = "0" * (len(self.array) - len(b)) + b
 		self.array = [int(x) for x in b]
-		

--- a/tests/test_acc.py
+++ b/tests/test_acc.py
@@ -79,4 +79,3 @@ def test_add_many_memberships():
 #         assert smerkle.verify_membership(acc, v, wit, n)
 
 #     w = smerkle.compute_non_membership_witness(acc, value, g, n, values)
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.