### PR TITLE
Fixed 3 issues of type: PYTHON_F401 throughout 3 files in repo.

### DIFF
--- a/smerkle/__init__.py
+++ b/smerkle/__init__.py
@@ -1,3 +1,0 @@
-from smerkle.tree import *
-from smerkle.bloom import *
-from smerkle.acc import *

--- a/smerkle/acc.py
+++ b/smerkle/acc.py
@@ -1,6 +1,4 @@
 """Main Library for Pyproofs"""
-import hashlib
-import math
 
 from Crypto.Util import number
 

--- a/tests/test_acc.py
+++ b/tests/test_acc.py
@@ -1,5 +1,4 @@
 """Tests functions in main.py"""
-import hashlib
 import random
 
 import smerkle


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        